### PR TITLE
promote: kian-coffee to 9023974

### DIFF
--- a/kubernetes/clusters/1276-prod/kian-coffee/kian-coffee/values.yaml
+++ b/kubernetes/clusters/1276-prod/kian-coffee/kian-coffee/values.yaml
@@ -1,19 +1,15 @@
 image:
   repository: "ghcr.io/techgardencode/kian.coffee"
-  tag: "latest@sha256:c17bbbfefd87f6d0a1ebdae52f6db2d5ecf5424636e45d7da43bd590a3d517e0"
-
+  tag: "90239740af13080250faef0af3f903f7ab4a4078"
 ports:
   - name: main
     containerPort: 80
-
 service:
   type: ClusterIP
-
 # Exposure: Tier 3 (Cloudflare Tunnel) + Internal
 httpRoute:
   enabled: true
   hostname: kian.coffee
-
 gateway:
   internal:
     enabled: true

--- a/kubernetes/clusters/1501-prod/kian-coffee/kian-coffee/values.yaml
+++ b/kubernetes/clusters/1501-prod/kian-coffee/kian-coffee/values.yaml
@@ -1,14 +1,11 @@
 image:
   repository: "ghcr.io/techgardencode/kian.coffee"
-  tag: "latest@sha256:c17bbbfefd87f6d0a1ebdae52f6db2d5ecf5424636e45d7da43bd590a3d517e0"
-
+  tag: "90239740af13080250faef0af3f903f7ab4a4078"
 ports:
   - name: main
     containerPort: 80
-
 service:
   type: LoadBalancer
-
 ingress:
   public: true
   annotations:


### PR DESCRIPTION
## Promote kian-coffee to production

**Image tag:** `90239740af13080250faef0af3f903f7ab4a4078`

### What's shipping
- Angular **20.2 → 21.2**
- Migrated to standalone components (removed `AppModule` + `AppRoutingModule`, now using `bootstrapApplication` + `provideRouter`)
- **Tailwind v3 → v4** — CSS-first, `@tailwindcss/postcss` plugin, no `tailwind.config.js`
- Removed unused deps (`@rrweb/types`, `@angular/platform-browser-dynamic`)
- Bumped jasmine/karma to 5.x/6.4.4, posthog-js to 1.369

### Dev verified
- https://dev.kian.coffee is serving the new build
- Tailwind v4 output confirmed (`@layer theme`, `@property --tw-font-weight`, CSS custom properties)
- Pod `kian-coffee-55d79964b8-wksdz` running on image tag `90239740af13...`

Merging this PR will deploy to production on **1276-prod** and **1501-prod** via ArgoCD.

---
*The auto-generated promote PR flow hit a workflow bug (the close-existing step deleted the current branch). Fixed in commit `fb2d9fa`; this PR opened manually with the same branch name and content that the workflow would have produced.*