### PR TITLE
fix(post-upgrade): tighten 3 low-priority items from sweep

### DIFF
--- a/kubernetes/clusters/1276-dev/hausparty/hausparty/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/hausparty/hausparty/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hausparty
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 12h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/hausparty/hausparty/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/hausparty/hausparty/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hausparty
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 12h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/shared/db-operators/mysql-operator/kustomization.yaml
+++ b/kubernetes/clusters/shared/db-operators/mysql-operator/kustomization.yaml
@@ -8,3 +8,12 @@ helmCharts:
     includeCRDs: true
     releaseName: mysql-operator
     namespace: db-operators
+
+patches:
+  - target:
+      kind: Deployment
+      name: mysql-operator
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
+        value: 30

--- a/kubernetes/clusters/shared/storage/nas-recovery/cronjob.yaml
+++ b/kubernetes/clusters/shared/storage/nas-recovery/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
   timeZone: Europe/Berlin
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       activeDeadlineSeconds: 120


### PR DESCRIPTION
## Summary
Three small, independent fixes for issues surfaced by the post-Talos-1.13.0 sweep. None are critical; bundling per request.

### 1. mysql-operator readiness probe (1276-prod)
`shared/db-operators/mysql-operator/kustomization.yaml`

Adds a strategic-merge patch bumping `initialDelaySeconds` from `1` to `30`. The operator writes `/tmp/mysql-operator-ready` a few seconds after start; the chart's `1s` initial delay + `3s` period × `3` failures gives only a 10s budget, so slow starts (post-reboot) trigger a transient `Unhealthy` warning event. Pod always reaches Ready in steady state.

### 2. hausparty ExternalSecret refresh interval (dev + prod)
`1276-{dev,prod}/hausparty/hausparty/externalsecret.yaml`

`refreshInterval: 1h` → `12h`. The hausparty ES has 8 individual `data[]` items, each triggering a separate BWS API call. ESO fires them concurrently, intermittently hitting BWS's burst rate limit (`429 Too Many Requests`). ESO retries succeed and the Secret converges (`Ready=True, SecretSynced`), but the recurring `UpdateFailed` warning is noisy.

12h cuts the burst frequency 12×. Force a sync when a secret actually rotates:
```bash
kubectl annotate externalsecret hausparty -n hausparty force-sync=$(date +%s) --overwrite
```

### 3. nas-recovery cronjob failure history (shared)
`shared/storage/nas-recovery/cronjob.yaml`

`failedJobsHistoryLimit: 3` → `1`. Three stale `Failed` job records (Apr 28–30) were lingering. The script uses `set -eu` and occasionally fails on `kubectl get/exec` races during pod transitions. Most recent run succeeded. Keeping only the latest failure reduces ledger noise; the script's actual robustness (e.g., `|| true` on remaining `kubectl get` calls, or apiserver health pre-check) can be revisited if a fresh failure is observed.

## Test plan
- [x] `kustomize build --enable-helm` clean for all four edited paths
- [x] mysql-operator rendered Deployment shows `initialDelaySeconds: 30`
- [x] hausparty ExternalSecrets render `refreshInterval: 12h` (ghcr-credentials kept at 1h)
- [x] nas-recovery CronJob renders `failedJobsHistoryLimit: 1`
- [ ] Post-merge: ArgoCD apps `1276-prod.db-operators.mysql-operator`, `1276-{dev,prod}.hausparty.hausparty`, `1276-{core,dev,prod}.storage.nas-recovery` reach Synced+Healthy on next reconcile
- [ ] Post-merge: mysql-operator pod restart shows no `Unhealthy` events for 60s after start
- [ ] Post-merge: 0 new `UpdateFailed` warning events on hausparty ES for 24h
- [ ] Post-merge: at most 1 stale `Failed` nas-recovery job record per cluster

## Out of scope
Items deferred per planning conversation:
- techgarden-blog DB grants (`permission denied for table profile`) — app-side, separate work
- step-issuer post-reboot warning — already self-healed (`Verified, Ready=True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)