### PR TITLE
feat(argocd): repo credentials for the private TechGarden repo

### DIFF
--- a/kubernetes/clusters/1276-core/argocd/argocd/base/repo-creds.yaml
+++ b/kubernetes/clusters/1276-core/argocd/argocd/base/repo-creds.yaml
@@ -1,0 +1,33 @@
+---
+# ArgoCD repository credentials for the (private) TechGarden app repos.
+# `repo-creds` is a URL-prefix template: it applies to every repo under the org
+# prefix below, so techgarden (and future product repos) are all covered by one
+# entry. The PAT (read-only Contents) is pulled from Bitwarden Secrets Manager.
+# The label is set on both the ExternalSecret (house style, propagated by ESO)
+# and the generated Secret's template so ArgoCD reliably recognises it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: techgardencode-repo-creds
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: techgardencode-repo-creds
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repo-creds
+      data:
+        type: git
+        url: https://github.com/TechGardenCode
+        username: x-access-token
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: "46d0db72-9f10-4571-bdd6-b47500219d1e"

--- a/kubernetes/clusters/1276-core/argocd/argocd/kustomization.yaml
+++ b/kubernetes/clusters/1276-core/argocd/argocd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - base/externalsecret.yaml
+  - base/repo-creds.yaml
   - base/configmap.yaml
   - base/pdb.yaml
   - base/step-ca-configmap.yaml


### PR DESCRIPTION
Adds ArgoCD repository credentials so it can read the **private** `TechGardenCode/techgarden` repo — the last piece needed for the `techgarden-dev` ApplicationSet (added in #225) to actually sync.

## What
- New `base/repo-creds.yaml` ExternalSecret (matches the existing ESO + `bitwarden-secretsmanager` ClusterSecretStore pattern) producing an `argocd.argoproj.io/secret-type: repo-creds` secret in the `argocd` namespace.
- **`repo-creds` URL-prefix template** (`https://github.com/TechGardenCode`) → covers techgarden and any future product repos with one entry.
- PAT (read-only Contents) pulled from Bitwarden Secrets Manager item `46d0db72-…219d1e`. Username `x-access-token` (token auth).
- Wired into `argocd/kustomization.yaml`.

## After merge
ArgoCD can read the repo → `techgarden-web` + `iris` Applications sync. Their images are already in GHCR with the dev overlay tags pinned to the latest SHA. Remaining app-config gap: `IRIS_OLLAMA_5090_HOST` in the iris dev overlay (pending the desktop's LAN IP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)