### PR TITLE
fix(keycloak): techgarden realm refreshTokenMaxReuse 0→2 — stop constant PWA logouts

### DIFF
--- a/kubernetes/clusters/1276-dev/keycloak/keycloak/base/realms/techgarden-realm.json
+++ b/kubernetes/clusters/1276-dev/keycloak/keycloak/base/realms/techgarden-realm.json
@@ -3,7 +3,7 @@
   "enabled": true,
   "accessTokenLifespan": 600,
   "revokeRefreshToken": true,
-  "refreshTokenMaxReuse": 0,
+  "refreshTokenMaxReuse": 2,
   "ssoSessionIdleTimeout": 1209600,
   "ssoSessionMaxLifespan": 2592000,
   "clients": [


### PR DESCRIPTION
## Problem

The deployed web app (`iris-web` PKCE client on the `techgarden` realm, `sso.dev.techgarden.gg`) signs users out constantly — kicked to Keycloak after a short PWA idle or randomly mid-use — despite session windows configured for **weeks** (SSO idle 14 d / max 30 d, offline idle 30 d).

Diagnosed from a live session: it's **not a timeout**, it's refresh-token rotation. With `revokeRefreshToken: true` and `refreshTokenMaxReuse: 0`, every refresh token is strictly single-use with **reuse detection**. A normal PWA races renews — `checkAuth()` on reopen firing alongside the periodic heartbeat, a second instance advancing the token, or a retried request re-presenting an already-rotated token. Present a rotated-out token and Keycloak treats it as a breach and **revokes the whole session**.

## Change

```diff
- "refreshTokenMaxReuse": 0,
+ "refreshTokenMaxReuse": 2,
```

One realm field on `techgarden` (`clusters/1276-dev/keycloak/.../techgarden-realm.json`). Grants a small reuse budget so the benign concurrency races no longer trip reuse detection — **while keeping `revokeRefreshToken: true`** so the theft tripwire for the passive replay case survives.

**Security:** reviewed under a security lens — this is the strictly-*more*-secure option at the same one-field scope as turning rotation off, because it retains reuse detection. It opens no new attack surface: the real exposure is the `localStorage` offline token → XSS, which is already blocked by the web image's strict `script-src 'self'` CSP and is unchanged by this field.

## How it applies

The realm seed is reconciled by the `keycloak-config-cli` ArgoCD **PostSync hook** (`no-delete`, runs every sync) — so on merge + sync this updates the running realm via the Admin API. No manual step. Realm-wide for `techgarden` (effectively just `iris-web`). Reversible by resetting to `0`.

## Validation

By **absence, not token stability** — rotation stays on, so tokens still rotate. After sync: no unexpected logouts over a day of normal PWA use, and no `invalid_grant`/session-revoke on reopen.

## Context

Full diagnosis, rejected alternatives (rotation-off; BFF), and the `offline_access` posture follow-up live in the companion app-repo PR: **TechGardenCode/techgarden#55** (ADR-0021).

🤖 Generated with [Claude Code](https://claude.com/claude-code)