### PR TITLE
feat(databases): fold iris + dopamenu onto shared postgresql cluster (ADR-0018)

### DIFF
--- a/kubernetes/clusters/1276-dev/databases/postgresql/app-externalsecrets.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/app-externalsecrets.yaml
@@ -29,7 +29,7 @@ spec:
   data:
     - secretKey: password
       remoteRef:
-        key: "REPLACE_WITH_iris_app_BW_UUID"
+        key: "6389718c-e6b6-4912-b4e1-b47e00553637"
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -54,4 +54,4 @@ spec:
   data:
     - secretKey: password
       remoteRef:
-        key: "REPLACE_WITH_dopamenu_app_BW_UUID"
+        key: "14eb7f8b-642b-4574-b623-b47e00556278"

--- a/kubernetes/clusters/1276-dev/databases/postgresql/app-externalsecrets.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/app-externalsecrets.yaml
@@ -1,0 +1,57 @@
+---
+# App-role passwords for the shared cluster's iris_app / dopamenu_app roles,
+# materialised into the `databases` namespace so `managed.roles.passwordSecret`
+# (cluster.yaml) can set them. type basic-auth + keys username/password +
+# cnpg.io/reload label are required by cnpg managed roles. The SAME Bitwarden
+# entry feeds the product-namespace app secret in the techgarden repo (password
+# parity). Placeholder UUIDs are intentional — ESO fails loud until the owner
+# creates the Bitwarden entries and replaces them (see the migration runbook).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: iris-db-app-credentials
+  namespace: databases
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: iris-db-app-credentials
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: iris_app
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: "REPLACE_WITH_iris_app_BW_UUID"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dopamenu-db-app-credentials
+  namespace: databases
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: dopamenu-db-app-credentials
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: dopamenu_app
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: "REPLACE_WITH_dopamenu_app_BW_UUID"

--- a/kubernetes/clusters/1276-dev/databases/postgresql/cluster.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/cluster.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   instances: 1
 
+  # NOTE (ADR-0018): no `imageName` is pinned here — this shared cluster runs the
+  # cnpg operator default operand image. iris needs pgvector (migration V6
+  # `CREATE EXTENSION vector`), which is NOT a core extension. Before the iris
+  # cutover, verify the operand image bundles pgvector and, if absent, pin
+  # `imageName` to a pgvector-bearing tag MATCHING the current PG major (a major
+  # downgrade is impossible). Changing the image rolls this live instance (it also
+  # hosts the `techgarden` DB), so treat it as a deliberate maintenance step.
+  # See techgarden docs/processes/shared-db-consolidation-runbook.md §2.
   enableSuperuserAccess: true
   superuserSecret:
     name: postgresql-superuser

--- a/kubernetes/clusters/1276-dev/databases/postgresql/cluster.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/cluster.yaml
@@ -45,3 +45,32 @@ spec:
       memory: 256Mi
     limits:
       memory: 512Mi
+
+  # iris + dopamenu app roles (ADR-0018 consolidation). LOGIN NOSUPERUSER
+  # NOBYPASSRLS is the RLS invariant — the services connect as these roles; the
+  # Flyway migrator connects as the cluster superuser `postgres`. Passwords come
+  # from ESO-materialised secrets (app-externalsecrets.yaml) in this namespace.
+  managed:
+    roles:
+      - name: iris_app
+        ensure: present
+        login: true
+        superuser: false
+        createdb: false
+        createrole: false
+        bypassrls: false
+        inherit: true
+        connectionLimit: -1
+        passwordSecret:
+          name: iris-db-app-credentials
+      - name: dopamenu_app
+        ensure: present
+        login: true
+        superuser: false
+        createdb: false
+        createrole: false
+        bypassrls: false
+        inherit: true
+        connectionLimit: -1
+        passwordSecret:
+          name: dopamenu-db-app-credentials

--- a/kubernetes/clusters/1276-dev/databases/postgresql/databases.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/databases.yaml
@@ -1,0 +1,26 @@
+---
+# iris + dopamenu databases on the shared `postgresql` cluster (ADR-0018).
+# databaseReclaimPolicy: retain => deleting the CR never drops the live database.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: iris-database
+  namespace: databases
+spec:
+  name: iris
+  owner: iris_app
+  cluster:
+    name: postgresql
+  databaseReclaimPolicy: retain
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: dopamenu-database
+  namespace: databases
+spec:
+  name: dopamenu
+  owner: dopamenu_app
+  cluster:
+    name: postgresql
+  databaseReclaimPolicy: retain

--- a/kubernetes/clusters/1276-dev/databases/postgresql/kustomization.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 
 resources:
   - externalsecret.yaml
+  - app-externalsecrets.yaml
   - cluster.yaml
+  - databases.yaml
   - init-sql.yaml


### PR DESCRIPTION
Adds the DB-side objects to the shared `postgresql` cluster (ns `databases`, dev `1276-dev`) so iris and dopamenu can fold off their dedicated cnpg `Cluster` CRs — Thread 1 / PR B of the platform-alignment DB consolidation (ADR-0018).

## What this adds
- **2 `Database` CRs** (`iris`, `dopamenu`, `databaseReclaimPolicy: retain`) on cluster `postgresql`.
- **2 `managed.roles`** (`iris_app`, `dopamenu_app`) — `LOGIN NOSUPERUSER NOBYPASSRLS`, no createdb/createrole. **This is the RLS invariant**: the services connect as these roles; the Flyway migrator connects as the shared cluster superuser `postgres`.
- **2 app-role ExternalSecrets** in `databases` ns (`iris-db-app-credentials`, `dopamenu-db-app-credentials`, `type: basic-auth` + `cnpg.io/reload`) so `managed.roles.passwordSecret` can set the passwords from Bitwarden.

First use of the cnpg `Database` CRD + `managed.roles` in this repo (operator 1.28). `postInitSQL` can't be used — it only runs at bootstrap, and this cluster is already running.

## ⚠️ Prerequisites before this can fully reconcile (owner action)
1. **Create 2 Bitwarden Secrets-Manager entries** — `iris_app` DB password, `dopamenu_app` DB password — and replace the `REPLACE_WITH_iris_app_BW_UUID` / `REPLACE_WITH_dopamenu_app_BW_UUID` placeholders in `app-externalsecrets.yaml`. (The superuser/migrator entry already exists and is reused.) ESO fails loud until then.
2. **pgvector pre-flight** — the shared cluster has no pinned `imageName`. Before the iris cutover, verify pgvector is available on the running operand image (`SELECT * FROM pg_available_extensions WHERE name='vector';`). If absent, pin `spec.imageName` to a pgvector-bundled tag **matching the current PG major** (a major downgrade is impossible) — a follow-up commit here, accepting the rolling restart. iris Flyway V6 runs `CREATE EXTENSION IF NOT EXISTS vector`.

## Sequencing
Merge this (PR B) first. The techgarden-repo PR C (deployment rewire) merges **only after** the owner runs the live iris data migration. Full sequence + rollback in the techgarden runbook `docs/processes/shared-db-consolidation-runbook.md`.

Verified with `kustomize build` (renders clean; 2 Database CRs; roles `NOSUPERUSER NOBYPASSRLS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)