### PR TITLE
chore(renovate): enforce 3-day minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended"],
   "platformAutomerge": false,
   "schedule": ["before 6am every weekday"],
+  "minimumReleaseAge": "3 days",
 
   "packageRules": [
     {


### PR DESCRIPTION
Adds `"minimumReleaseAge": "3 days"` to the top-level Renovate config so PRs are held until the target release is at least 3 days old.

## Why
Renovate currently opens dependency PRs the moment a release lands — e.g. argo-cd chart v10.1.2 appeared a single day after publication. Adopting brand-new releases risks day-1 regressions / zero-days. This bakes the "no releases <3 days old" policy directly into Renovate (with the default strict `internalChecksFilter`) instead of relying on manual gatekeeping each cycle.

## Scope
- `renovate.json` only — not an ArgoCD-tracked path, so no cluster/sync impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)