### PR TITLE
fix(keycloak): enable Remember-Me on techgarden realm — persistent SSO cookie

### DIFF
--- a/kubernetes/clusters/1276-dev/keycloak/keycloak/base/realms/techgarden-realm.json
+++ b/kubernetes/clusters/1276-dev/keycloak/keycloak/base/realms/techgarden-realm.json
@@ -6,6 +6,9 @@
   "refreshTokenMaxReuse": 2,
   "ssoSessionIdleTimeout": 1209600,
   "ssoSessionMaxLifespan": 2592000,
+  "rememberMe": true,
+  "ssoSessionIdleTimeoutRememberMe": 2592000,
+  "ssoSessionMaxLifespanRememberMe": 5184000,
   "offlineSessionMaxLifespanEnabled": true,
   "offlineSessionMaxLifespan": 5184000,
   "clients": [


### PR DESCRIPTION
Defense-in-depth for the cold-boot logout — pairs with techgarden **PR #60** ([ADR-0024](https://github.com/TechGardenCode/techgarden/blob/feature/web-persistent-session/projects/iris/docs/decisions/0024-cold-boot-refresh-and-remember-me.md)).

The client-side fix (`checkAuthIncludingServer`) restores the session from the 30-day offline refresh token on reopen, so the primary path no longer depends on the SSO cookie. Remember-Me hardens the **rare fallback**: when the client refresh transiently fails (flaky mobile network) but the Keycloak SSO session is still alive, the `authorize()` redirect becomes **silent** instead of a login page — because the SSO cookie is now persistent rather than a browser-session cookie that dies on full close.

## Change (`techgarden-realm.json`)

```
+ "rememberMe": true,
+ "ssoSessionIdleTimeoutRememberMe": 2592000,   // 30d, aligned to offline idle
+ "ssoSessionMaxLifespanRememberMe": 5184000,   // 60d, aligned to offline max
```

Both resume paths (offline refresh token / persistent SSO cookie) now share one 30d-idle / 60d-max schedule.

## Note

Default login theme → the checkbox is **unchecked** by default; tick "Remember me" once on the next interactive login and `KEYCLOAK_REMEMBER_ME` keeps it pre-checked thereafter. A custom theme to pre-check it was rejected as over-engineering for a single-user app.

Takes effect once merged + keycloak-config-cli reconciles the realm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)