### PR TITLE
chore(external-secrets): refreshInterval 1h → 24h (stop BWS restart stampede)

### DIFF
--- a/kubernetes/clusters/1276-core/argocd/argocd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/argocd/argocd/base/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     argocd.argoproj.io/secret-type: cluster
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -29,7 +29,7 @@ metadata:
   labels:
     argocd.argoproj.io/secret-type: cluster
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -52,7 +52,7 @@ metadata:
   labels:
     argocd.argoproj.io/secret-type: cluster
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -73,7 +73,7 @@ kind: ExternalSecret
 metadata:
   name: argocd-webhook-secret
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/argocd/argocd/base/repo-creds.yaml
+++ b/kubernetes/clusters/1276-core/argocd/argocd/base/repo-creds.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     argocd.argoproj.io/secret-type: repo-creds
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/observability/glitchtip-db/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/observability/glitchtip-db/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: glitchtip-db-superuser
   namespace: observability
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -29,7 +29,7 @@ metadata:
   name: glitchtip-db-app-credentials
   namespace: observability
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/observability/glitchtip/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/observability/glitchtip/base/externalsecret.yaml
@@ -20,7 +20,7 @@ metadata:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/sync-wave: "-10"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/observability/openpanel-db/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/observability/openpanel-db/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openpanel-db-superuser
   namespace: observability
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -29,7 +29,7 @@ metadata:
   name: openpanel-db-app-credentials
   namespace: observability
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/observability/openpanel/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/observability/openpanel/base/externalsecret.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/pki/step-ca/base/externalsecrets.yaml
+++ b/kubernetes/clusters/1276-core/pki/step-ca/base/externalsecrets.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: step-ca-step-certificates-ca-password
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -19,7 +19,7 @@ kind: ExternalSecret
 metadata:
   name: step-ca-step-certificates-certs
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -37,7 +37,7 @@ kind: ExternalSecret
 metadata:
   name: step-ca-step-certificates-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager
@@ -55,7 +55,7 @@ kind: ExternalSecret
 metadata:
   name: step-ca-step-certificates-secrets
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-core/pki/step-issuer/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/pki/step-issuer/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: step-issuer-provisioner-password
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-core/platform/cloudflared/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/platform/cloudflared/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflared-tunnel-credentials
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/platform/external-dns-cloudflare/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/platform/external-dns-cloudflare/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflare-external-dns
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-core/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-core/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-core/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-core/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-core/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-dev/databases/postgresql/app-externalsecrets.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/app-externalsecrets.yaml
@@ -12,7 +12,7 @@ metadata:
   name: iris-db-app-credentials
   namespace: databases
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -37,7 +37,7 @@ metadata:
   name: dopamenu-db-app-credentials
   namespace: databases
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/databases/postgresql/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/databases/postgresql/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: postgresql-superuser
   namespace: databases
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -29,7 +29,7 @@ metadata:
   name: postgresql-app-credentials
   namespace: databases
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/hausparty/hausparty-db/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/hausparty/hausparty-db/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hausparty-db-superuser
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -29,7 +29,7 @@ metadata:
   name: hausparty-db-app-credentials
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/hausparty/hausparty/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/hausparty/hausparty/externalsecret.yaml
@@ -40,7 +40,7 @@ metadata:
   name: ghcr-credentials
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/keycloak/keycloak-db/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/keycloak/keycloak-db/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: keycloak-db-superuser
   namespace: keycloak
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -29,7 +29,7 @@ metadata:
   name: keycloak-db-app-credentials
   namespace: keycloak
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/keycloak/keycloak/base/externalsecret-realm.yaml
+++ b/kubernetes/clusters/1276-dev/keycloak/keycloak/base/externalsecret-realm.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/keycloak/keycloak/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/keycloak/keycloak/base/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: keycloak-admin
   namespace: keycloak
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/kian-coffee/kian-coffee-blog/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/kian-coffee/kian-coffee-blog/externalsecret.yaml
@@ -13,7 +13,7 @@ metadata:
   name: kian-coffee-blog
   namespace: kian-coffee
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/kian-coffee/kian-coffee-db/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/kian-coffee/kian-coffee-db/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kian-coffee-db-superuser
   namespace: kian-coffee
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -33,7 +33,7 @@ metadata:
   name: kian-coffee-db-app-credentials
   namespace: kian-coffee
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/kian-coffee/kian-coffee/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/kian-coffee/kian-coffee/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kian-coffee
   namespace: kian-coffee
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/pki/step-issuer/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/pki/step-issuer/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: step-issuer-provisioner-password
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-dev/platform/cloudflared/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/platform/cloudflared/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflared-tunnel-credentials
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/platform/external-dns-cloudflare/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/platform/external-dns-cloudflare/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflare-external-dns
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/wiki/wiki/externalsecret-github.yaml
+++ b/kubernetes/clusters/1276-dev/wiki/wiki/externalsecret-github.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-deploy-token
   namespace: wiki
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-dev/wiki/wiki/externalsecret.yaml
+++ b/kubernetes/clusters/1276-dev/wiki/wiki/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ghcr-credentials
   namespace: wiki
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/hausparty/hausparty-db/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/hausparty/hausparty-db/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hausparty-db-superuser
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -29,7 +29,7 @@ metadata:
   name: hausparty-db-app-credentials
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/hausparty/hausparty/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/hausparty/hausparty/externalsecret.yaml
@@ -43,7 +43,7 @@ metadata:
   name: ghcr-credentials
   namespace: hausparty
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/keycloak/keycloak-db/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/keycloak/keycloak-db/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: keycloak-db-superuser
   namespace: keycloak
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore
@@ -29,7 +29,7 @@ metadata:
   name: keycloak-db-app-credentials
   namespace: keycloak
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/keycloak/keycloak/base/externalsecret-realm.yaml
+++ b/kubernetes/clusters/1276-prod/keycloak/keycloak/base/externalsecret-realm.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/keycloak/keycloak/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/keycloak/keycloak/base/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: keycloak-admin
   namespace: keycloak
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/kian-coffee/kian-coffee/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/kian-coffee/kian-coffee/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kian-coffee
   namespace: kian-coffee
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/pelican/mariadb/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/pelican/mariadb/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: mariadb
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/pelican/pelican/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/pelican/pelican/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: pelican
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/pelican/redis/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/pelican/redis/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: redis
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/pki/step-issuer/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/pki/step-issuer/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: step-issuer-provisioner-password
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1276-prod/platform/cloudflared/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/platform/cloudflared/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflared-tunnel-credentials
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/platform/external-dns-cloudflare/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/platform/external-dns-cloudflare/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflare-external-dns
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/wiki/wiki/externalsecret-github.yaml
+++ b/kubernetes/clusters/1276-prod/wiki/wiki/externalsecret-github.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-deploy-token
   namespace: wiki
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1276-prod/wiki/wiki/externalsecret.yaml
+++ b/kubernetes/clusters/1276-prod/wiki/wiki/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ghcr-credentials
   namespace: wiki
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/kian-coffee/kian-coffee/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/kian-coffee/kian-coffee/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kian-coffee
   namespace: kian-coffee
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/pki/step-issuer/base/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/pki/step-issuer/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: step-issuer-provisioner-password
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/1501-prod/platform/cloudflared/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/platform/cloudflared/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflared-tunnel-credentials
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/platform/external-dns-cloudflare/base/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/platform/external-dns-cloudflare/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflare-external-dns
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/storage/democratic-csi-iscsi-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/storage/democratic-csi-iscsi-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-iscsi-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/storage/democratic-csi-nfs-hdd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/storage/democratic-csi-nfs-ssd/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: democratic-csi-nfs-ssd-driver-config
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/wiki/wiki/externalsecret-github.yaml
+++ b/kubernetes/clusters/1501-prod/wiki/wiki/externalsecret-github.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-deploy-token
   namespace: wiki
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/1501-prod/wiki/wiki/externalsecret.yaml
+++ b/kubernetes/clusters/1501-prod/wiki/wiki/externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ghcr-credentials
   namespace: wiki
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/shared/cert-manager/cert-manager/base/cluster-issuer.yaml
+++ b/kubernetes/clusters/shared/cert-manager/cert-manager/base/cluster-issuer.yaml
@@ -21,7 +21,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflare-api-token-secret
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager

--- a/kubernetes/clusters/shared/platform/external-dns-internal/base/externalsecret.yaml
+++ b/kubernetes/clusters/shared/platform/external-dns-internal/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: technitium-dns
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secretsmanager
     kind: ClusterSecretStore

--- a/kubernetes/clusters/shared/platform/external-secrets/base/externalsecret.yaml
+++ b/kubernetes/clusters/shared/platform/external-secrets/base/externalsecret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: bitwarden
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: bitwarden-secretsmanager


### PR DESCRIPTION
## What

Bump `refreshInterval` from `1h` → `24h` on all 79 ExternalSecrets across the fleet (dev/core/shared in commit 1, 1276-prod/1501-prod in commit 2).

## Why

The BWS rate-limit incident was a **thundering herd on ESO controller restart** (shared-path ESO upgrade restarted all clusters' controllers at once → synchronized re-fetch of every secret → BWS org 429 → stragglers stuck `SecretSyncedError`).

On restart, ESO only calls Bitwarden for ExternalSecrets whose interval has **elapsed since `status.refreshTime`** (which survives the pod restart). At `1h`, a restart finds most secrets due → full burst. At `24h`, almost nothing is due at any given restart → the burst on the next ESO upgrade largely disappears. Also cuts steady-state BWS load ~24×.

Every secret here is static / manually-managed, so hourly refresh bought nothing. The 2× `12h` secrets already sit above the danger threshold and are left untouched.

## Rollout / risk

- Merging syncs all clusters via ArgoCD. The apply forces a one-time refresh of each ExternalSecret (generation bump), but spread across 4 independent rate-limited ESO controllers over ArgoCD's sync window — a gentle profile, not the tight all-at-once chart-restart spike.
- A transient 429 self-heals: ESO keeps last-good values and retries with backoff. No outage risk.
- Split into non-prod / prod commits per the prod safety gate.

## Deferred (follow-up if needed)

- Cap ESO `concurrent` for the edge cases 24h doesn't cover (fresh bootstrap, ESO down >24h).
- Hub-and-spoke cache (one fetcher → in-cluster mirror) only if steady-state ever actually grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)